### PR TITLE
Add Active mode flag and regex to limit services tracked.

### DIFF
--- a/Tridion.Aws.Status/Services.cs
+++ b/Tridion.Aws.Status/Services.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.ServiceProcess;
+using System.Text.RegularExpressions;
+using System.Web.Configuration;
 
 
 namespace Tridion.Aws.Status
@@ -11,10 +13,9 @@ namespace Tridion.Aws.Status
     {
         internal Dictionary<string, ServiceController> GetListOfServices()
         {
-            var servicesList = new List<Process>();
-            ServiceController[] services = ServiceController.GetServices().Where(s => s.DisplayName.ToLower().StartsWith("sdl ") || s.DisplayName.ToLower().StartsWith("tridion ")).ToArray();
-            var servicesStatus = services.ToDictionary(s => s.ServiceName, s => s);
-            return servicesStatus;
+            var rx = new Regex(WebConfigurationManager.AppSettings["regexOfServicesToCheckIfRunning"], RegexOptions.IgnoreCase);
+            var services = ServiceController.GetServices().Where(s => rx.IsMatch(s.DisplayName) ).ToArray();
+            return services.ToDictionary(s => s.ServiceName, s => s);
         }
     }
 

--- a/Tridion.Aws.Status/Web.config
+++ b/Tridion.Aws.Status/Web.config
@@ -2,10 +2,11 @@
 <configuration>
 
   <appSettings>
-    <!-- "regexOfServicesToCheckIfRunning": a regular expression, all services that match will be checked to see 
-                                            if they are set to automatic and are running and return 200 if all 
-                                            running and 500 if some are stopped that are set to automatic  -->
-    <add key="regexOfServicesToCheckIfRunning" value="SDL Web|Tridion" />
+    <!-- "regexOfServicesToCheckIfRunning": a regular expression, all services set to automatic start that match will be checked to see 
+                                            if they are running, if they are all running a 200 status is returned, if any are not running then a 500
+                                            status is returned.
+                                            Services not set to automatic start are ignored.-->
+    <add key="regexOfServicesToCheckIfRunning" value="(SDL Web|Tridion) Content Manager Service Host" />
 
 
     <!-- "active"

--- a/Tridion.Aws.Status/Web.config
+++ b/Tridion.Aws.Status/Web.config
@@ -1,17 +1,20 @@
 ﻿<?xml version="1.0"?>
-<!--
-  For more information on how to configure your ASP.NET application, please visit
-  https://go.microsoft.com/fwlink/?LinkId=169433
-  -->
 <configuration>
-  <!--
-    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
-    The following attributes can be set on the <httpRuntime> tag.
-      <system.Web>
-        <httpRuntime targetFramework="4.6.2" />
-      </system.Web>
-  -->
+  <appSettings>
+    <!-- "regexOfServicesToCheckIfRunning": a regular expression, all services that match will be checked to see 
+                                            if they are set to automatic and are running and return 200 if all 
+                                            running and 500 if some are stopped that are set to automatic  -->
+    <add key="regexOfServicesToCheckIfRunning" value="SDL Web|Tridion" />
+
+
+    <!-- "active"
+                  * true  :  Stopped services result in a 500 response
+                  * false :  A 200 response is sent no matter what (useful for when doing maintenance and you need 
+                             to restart services but don`t want a 500 response sent to the Load Balancer test page)
+    . -->
+    <add key="active" value="true" />
+  </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.6.2"/>
     <httpRuntime targetFramework="4.5.2"/>

--- a/Tridion.Aws.Status/tridionStatus.ashx.cs
+++ b/Tridion.Aws.Status/tridionStatus.ashx.cs
@@ -23,8 +23,10 @@ namespace Tridion.Aws.Status
             context.Response.Write(Environment.MachineName + "\r\n");
 
 
-            if (!bool.TryParse(WebConfigurationManager.AppSettings["active"], out var activeMode))
+            bool activeMode;
+            if (!bool.TryParse(WebConfigurationManager.AppSettings["active"], out activeMode))
             {
+
 
                 context.Response.StatusCode = 500;
             }

--- a/Tridion.Aws.Status/tridionStatus.ashx.cs
+++ b/Tridion.Aws.Status/tridionStatus.ashx.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.ServiceProcess;
 using System.Web;
+using System.Web.Configuration;
 
 namespace Tridion.Aws.Status
 {
@@ -19,19 +21,40 @@ namespace Tridion.Aws.Status
 
             context.Response.ContentType = "text/plain";
             context.Response.Write(Environment.MachineName + "\r\n");
+
+
+            if (!bool.TryParse(WebConfigurationManager.AppSettings["active"], out var activeMode))
+            {
+
+                context.Response.StatusCode = 500;
+            }
+
+            if (!activeMode)
+            {
+                context.Response.Write("*************************************************************************\r\n");
+                context.Response.Write("*                                                                       *\r\n");
+                context.Response.Write("*                                                                       *\r\n");
+                context.Response.Write("*                      Services are not monitored                       *\r\n");
+                context.Response.Write("*                      active mode is set false in config               *\r\n");
+                context.Response.Write("*                                                                       *\r\n");
+                context.Response.Write("*                                                                       *\r\n");
+                context.Response.Write("*************************************************************************\r\n");
+                context.Response.StatusCode = 200;
+            }
+
             var svcList = s.GetListOfServices();
-            bool hasError = false;
+            var hasError = false;
             foreach (var service in svcList)
             {
 
-                if (service.Value.Status != ServiceControllerStatus.Running &&
-                    service.Value.StartType != ServiceStartMode.Disabled)
+                if (activeMode && service.Value.Status != ServiceControllerStatus.Running &&
+                    service.Value.StartType == ServiceStartMode.Automatic)
                 {
                     hasError = true;
                 }
                 context.Response.Write(service.Value.DisplayName + ":" + service.Value.Status + Environment.NewLine);
-
             }
+            context.Response.Write(hasError ? "Error" : "OK");
             context.Response.StatusCode = hasError ? 500 : 200;
 
         }


### PR DESCRIPTION
tridionted
* Add Regex Options, to choose which services to monitor, and set if active to allow maintenance mode where services are not monitored.
* change typo on activeMode Variable used to set if the tool is set to active mode or not
* improve wording on the web.config to make it clearer
